### PR TITLE
hardwired https to make that redirect really work as advertised

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -15,7 +15,7 @@ var app = express()
         if (req.secure) {
             return next();
         }
-        res.redirect(req.protocol+'://'+req.hostname+':'+httpsport+req.originalUrl);
+        res.redirect("https"+'://'+req.hostname+':'+httpsport+req.originalUrl);
     })//redirects all http request to https
     .use(express.static(path.join(__dirname, 'public')))//path to examples
     .use("/webrtc",webrtc(xirsys));//watch API calls


### PR DESCRIPTION
Maybe there's a magic setting to get around this, but you're not really redirecting to https if you just use req.protocol.  Thanks! 